### PR TITLE
Barcodes

### DIFF
--- a/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/core/BarcodeSpec.kt
+++ b/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/core/BarcodeSpec.kt
@@ -1,0 +1,130 @@
+/*
+ *    Copyright 2022 Ondřej Karmazín
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package cz.multiplatform.escpos4k.core
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+
+/**
+ * A sealed hierarchy of supported barcodes. Each `BarcodeSpec` is instantiated via a factory
+ * function that validates the input arguments and returns an `Either<SpecificError, BarcodeSpec>`.
+ * The factory function ensures that only valid instances can be created.
+ *
+ * Example:
+ * ```
+ * printer.print {
+ *   val qrCode: Either<QrCodeError, QRCodeSpec> = BarcodeSpec.QRCodeSpec("hello")
+ *
+ *   // Print the QR code or an error:
+ *   qrCode
+ *     .tap(::barcode)
+ *     .tapLeft { err ->
+ *       line("Could not construct QR code:")
+ *       line(err.toString())
+ *     }
+ * }
+ * ```
+ *
+ * Barcode printing is **not affected** by styles such as `bold`, `underline`, `italics` etc.
+ *
+ * Barcode printing **is** affected by `textSize`, `upside-down mode`, `text rotation`.
+ */
+public sealed class BarcodeSpec {
+
+  internal abstract fun asCommand(): Command
+
+  /**
+   * Print a QR Code.
+   *
+   * `text.length` must be in `<1..7089>`, but the upper limit of 7k can only be achieved with fully
+   * numeric `text`. The realistic limit for alphanumeric content is about **`2k`**.
+   */
+  public class QRCodeSpec
+  private constructor(
+      public val text: String,
+      public val errorCorrection: QrCorrectionLevel,
+  ) : BarcodeSpec() {
+
+    override fun asCommand(): Command.QrCode {
+      return Command.QrCode(text, errorCorrection)
+    }
+
+    public sealed class QrCodeError {
+      public object EmptyContent : QrCodeError()
+      public object TooLong : QrCodeError()
+    }
+
+    override fun equals(other: Any?): Boolean {
+      if (this === other) return true
+      if (other == null || this::class != other::class) return false
+
+      other as QRCodeSpec
+
+      if (text != other.text) return false
+      if (errorCorrection != other.errorCorrection) return false
+
+      return true
+    }
+
+    override fun hashCode(): Int {
+      var result = text.hashCode()
+      result = 31 * result + errorCorrection.hashCode()
+      return result
+    }
+
+    override fun toString(): String {
+      return "QRCodeSpec(text='$text', errorCorrection=$errorCorrection)"
+    }
+
+    public companion object {
+      private const val maxLength = 7089
+
+      /**
+       * Print a QR Code.
+       *
+       * `text.length` must be in `<1..7089>`, but the upper limit of 7k can only be achieved with
+       * fully numeric `text`. The realistic limit for random text content is about **`2k`**.
+       */
+      public fun create(
+          text: String,
+          errorCorrection: QrCorrectionLevel = QrCorrectionLevel.L
+      ): Either<QrCodeError, QRCodeSpec> {
+        if (text.isEmpty()) {
+          return QrCodeError.EmptyContent.left()
+        }
+
+        if (text.length > maxLength) {
+          return QrCodeError.TooLong.left()
+        }
+
+        return QRCodeSpec(text, errorCorrection).right()
+      }
+    }
+  }
+}
+
+public enum class QrCorrectionLevel(internal val level: Byte) {
+  /** 7 % (approx.) */
+  L(48),
+  /** 15 % (approx.) */
+  M(49),
+  /** 25 % (approx.) */
+  Q(50),
+  /** 30 % (approx.) */
+  H(51)
+}

--- a/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/core/Command.kt
+++ b/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/core/Command.kt
@@ -157,7 +157,7 @@ internal sealed class Command {
     }
   }
 
-  class Justify(val alignment: TextAlignment) : Command() {
+  class Justify(private val alignment: TextAlignment) : Command() {
     private val content = byteArrayOf(27, 97, alignment.value)
 
     override fun bytes(): ByteArray = content.copyOf()
@@ -225,8 +225,6 @@ internal sealed class Command {
     private val content: ByteArray
 
     init {
-      require(content.isNotEmpty()) { "Cannot print QR code with no content." }
-
       /*
         THE DATA TRANSMISSION FUNCTION:
         - Transmits `k` bytes d1..dk to the printer.
@@ -280,17 +278,6 @@ internal sealed class Command {
       return "QrCode(content=${content.contentToString()})"
     }
   }
-}
-
-public enum class QrCorrectionLevel(internal val level: Byte) {
-  /** 7 % (approx.) */
-  L(48),
-  /** 15 % (approx.) */
-  M(49),
-  /** 25 % (approx.) */
-  Q(50),
-  /** 30 % (approx.) */
-  H(51)
 }
 
 public enum class TextAlignment(internal val value: Byte) {

--- a/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/core/Command.kt
+++ b/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/core/Command.kt
@@ -225,20 +225,6 @@ internal sealed class Command {
     private val content: ByteArray
 
     init {
-      /*
-        THE DATA TRANSMISSION FUNCTION:
-        - Transmits `k` bytes d1..dk to the printer.
-        - Requires at least one byte of data.
-        - Important!!! The size information we send with pL and pH is in range 4-7092
-
-        29 40 107 pL pH 49 80 48 d1...dk
-
-        Spec:
-        (pL + pH × 256) = 4 – 7092
-        d = 0 – 255
-        k = (pL + pH × 256) − 3
-      */
-
       @Suppress("JoinDeclarationAndAssignment") //
       var data: ByteArray
 
@@ -276,6 +262,53 @@ internal sealed class Command {
 
     override fun toString(): String {
       return "QrCode(content=${content.contentToString()})"
+    }
+  }
+
+  class AztecCode(
+      content: String,
+      errorCorrection: Int,
+  ) : Command() {
+    private val content: ByteArray
+
+    init {
+      @Suppress("JoinDeclarationAndAssignment") //
+      var data: ByteArray
+
+      // 1. Set the EC level
+      data = byteArrayOf(29, 40, 107, 3, 0, 53, 69, errorCorrection.toByte())
+
+      // 2. Send the content to the printer. This does not initiate the print process, it merely
+      //    stores the data in the printer's symbol buffer.
+      val contentBytes = content.encodeToByteArray()
+      val base = contentBytes.size + 3
+      val (pL, pH) = base.toByte() to (base shr 8).toByte()
+      data += byteArrayOf(29, 40, 107, pL, pH, 53, 80, 48, *contentBytes)
+
+      // 3. Send the print command. This will print the data from step 2.
+      data += byteArrayOf(29, 40, 107, 3, 0, 53, 81, 48)
+      this.content = data
+    }
+
+    override fun bytes(): ByteArray = content.copyOf()
+
+    override fun equals(other: Any?): Boolean {
+      if (this === other) return true
+      if (other == null || this::class != other::class) return false
+
+      other as AztecCode
+
+      if (!content.contentEquals(other.content)) return false
+
+      return true
+    }
+
+    override fun hashCode(): Int {
+      return content.contentHashCode()
+    }
+
+    override fun toString(): String {
+      return "AztecCode(content=${content.contentToString()})"
     }
   }
 }

--- a/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/core/Command.kt
+++ b/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/core/Command.kt
@@ -218,9 +218,9 @@ internal sealed class Command {
     override fun bytes(): ByteArray = byteArrayOf(29, 86, 1)
   }
 
-  class QrCode(
+  class QRCode(
       content: String,
-      errorCorrection: QrCorrectionLevel,
+      errorCorrection: QRCorrectionLevel,
   ) : Command() {
     private val content: ByteArray
 
@@ -249,7 +249,7 @@ internal sealed class Command {
       if (this === other) return true
       if (other == null || this::class != other::class) return false
 
-      other as QrCode
+      other as QRCode
 
       if (!content.contentEquals(other.content)) return false
 
@@ -261,7 +261,7 @@ internal sealed class Command {
     }
 
     override fun toString(): String {
-      return "QrCode(content=${content.contentToString()})"
+      return "QRCode(content=${content.contentToString()})"
     }
   }
 
@@ -354,7 +354,7 @@ internal sealed class Command {
     }
   }
 
-  class UPC_A(content: String, hri: HriPosition) : Command() {
+  class UPCA(content: String, hri: HriPosition) : Command() {
     private val content: ByteArray
 
     init {
@@ -380,7 +380,7 @@ internal sealed class Command {
       if (this === other) return true
       if (other == null || this::class != other::class) return false
 
-      other as UPC_A
+      other as UPCA
 
       if (!content.contentEquals(other.content)) return false
 
@@ -392,7 +392,48 @@ internal sealed class Command {
     }
 
     override fun toString(): String {
-      return "UPC_A(content=${content.contentToString()})"
+      return "UPCA(content=${content.contentToString()})"
+    }
+  }
+
+  class EAN13(content: String, hri: HriPosition) : Command() {
+    private val content: ByteArray
+
+    init {
+      @Suppress("JoinDeclarationAndAssignment") //
+      var data: ByteArray
+
+      // 1. Set the HRI position and select the HRI font.
+      //    The last 0 is "Font A". We need to specify this because there is no default value for
+      //    the font. If we just set the position, there would be a space for the HRI, but it would
+      //    be blank
+      data = byteArrayOf(29, 72, hri.position, 29, 102, 0)
+
+      // 2. Print the barcode
+      val d = content.map { it.digitToInt().toByte() }.toByteArray()
+      data += byteArrayOf(29, 107, 67, 13, *d)
+
+      this.content = data
+    }
+    override fun bytes(): ByteArray = content.copyOf()
+
+    override fun equals(other: Any?): Boolean {
+      if (this === other) return true
+      if (other == null || this::class != other::class) return false
+
+      other as EAN13
+
+      if (!content.contentEquals(other.content)) return false
+
+      return true
+    }
+
+    override fun hashCode(): Int {
+      return content.contentHashCode()
+    }
+
+    override fun toString(): String {
+      return "EAN13(content=${content.contentToString()})"
     }
   }
 }

--- a/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/core/Command.kt
+++ b/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/core/Command.kt
@@ -415,6 +415,7 @@ internal sealed class Command {
 
       this.content = data
     }
+
     override fun bytes(): ByteArray = content.copyOf()
 
     override fun equals(other: Any?): Boolean {
@@ -434,6 +435,48 @@ internal sealed class Command {
 
     override fun toString(): String {
       return "EAN13(content=${content.contentToString()})"
+    }
+  }
+
+  class EAN8(content: String, hri: HriPosition) : Command() {
+    private val content: ByteArray
+
+    init {
+      @Suppress("JoinDeclarationAndAssignment") //
+      var data: ByteArray
+
+      // 1. Set the HRI position and select the HRI font.
+      //    The last 0 is "Font A". We need to specify this because there is no default value for
+      //    the font. If we just set the position, there would be a space for the HRI, but it would
+      //    be blank
+      data = byteArrayOf(29, 72, hri.position, 29, 102, 0)
+
+      // 2. Print the barcode
+      val d = content.map { it.digitToInt().toByte() }.toByteArray()
+      data += byteArrayOf(29, 107, 68, 8, *d)
+
+      this.content = data
+    }
+
+    override fun bytes(): ByteArray = content.copyOf()
+
+    override fun equals(other: Any?): Boolean {
+      if (this === other) return true
+      if (other == null || this::class != other::class) return false
+
+      other as EAN8
+
+      if (!content.contentEquals(other.content)) return false
+
+      return true
+    }
+
+    override fun hashCode(): Int {
+      return content.contentHashCode()
+    }
+
+    override fun toString(): String {
+      return "EAN8(content=${content.contentToString()})"
     }
   }
 }

--- a/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/core/Command.kt
+++ b/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/core/Command.kt
@@ -333,6 +333,7 @@ internal sealed class Command {
     }
 
     override fun bytes(): ByteArray = content.copyOf()
+
     override fun equals(other: Any?): Boolean {
       if (this === other) return true
       if (other == null || this::class != other::class) return false
@@ -350,6 +351,48 @@ internal sealed class Command {
 
     override fun toString(): String {
       return "DataMatrix(content=${content.contentToString()})"
+    }
+  }
+
+  class UPC_A(content: String, hri: HriPosition) : Command() {
+    private val content: ByteArray
+
+    init {
+      @Suppress("JoinDeclarationAndAssignment") //
+      var data: ByteArray
+
+      // 1. Set the HRI position and select the HRI font.
+      //    The last 0 is "Font A". We need to specify this because there is no default value for
+      //    the font. If we just set the position, there would be a space for the HRI, but it would
+      //    be blank
+      data = byteArrayOf(29, 72, hri.position, 29, 102, 0)
+
+      // 2. Print the barcode
+      val d = content.map { it.digitToInt().toByte() }.toByteArray()
+      data += byteArrayOf(29, 107, 65, 12, *d)
+
+      this.content = data
+    }
+
+    override fun bytes(): ByteArray = content.copyOf()
+
+    override fun equals(other: Any?): Boolean {
+      if (this === other) return true
+      if (other == null || this::class != other::class) return false
+
+      other as UPC_A
+
+      if (!content.contentEquals(other.content)) return false
+
+      return true
+    }
+
+    override fun hashCode(): Int {
+      return content.contentHashCode()
+    }
+
+    override fun toString(): String {
+      return "UPC_A(content=${content.contentToString()})"
     }
   }
 }

--- a/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/core/Command.kt
+++ b/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/core/Command.kt
@@ -311,6 +311,47 @@ internal sealed class Command {
       return "AztecCode(content=${content.contentToString()})"
     }
   }
+
+  class DataMatrix(content: String) : Command() {
+    private val content: ByteArray
+
+    init {
+      var data: ByteArray
+
+      // Note: Unlike other codes, DataMatrix sets its error correction on its own.
+
+      // 1. Send the content to the printer. This does not initiate the print process, it merely
+      //    stores the data in the printer's symbol buffer.
+      val contentBytes = content.encodeToByteArray()
+      val base = contentBytes.size + 3
+      val (pL, pH) = base.toByte() to (base shr 8).toByte()
+      data = byteArrayOf(29, 40, 107, pL, pH, 54, 80, 48, *contentBytes)
+
+      // 2. Send the print command. This will print the data from step 1.
+      data += byteArrayOf(29, 40, 107, 3, 0, 54, 81, 48)
+      this.content = data
+    }
+
+    override fun bytes(): ByteArray = content.copyOf()
+    override fun equals(other: Any?): Boolean {
+      if (this === other) return true
+      if (other == null || this::class != other::class) return false
+
+      other as DataMatrix
+
+      if (!content.contentEquals(other.content)) return false
+
+      return true
+    }
+
+    override fun hashCode(): Int {
+      return content.contentHashCode()
+    }
+
+    override fun toString(): String {
+      return "DataMatrix(content=${content.contentToString()})"
+    }
+  }
 }
 
 public enum class TextAlignment(internal val value: Byte) {

--- a/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/core/CommandBuilder.kt
+++ b/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/core/CommandBuilder.kt
@@ -387,14 +387,12 @@ internal constructor(
   }
 
   /**
-   * Print a QR Code containing the [content].
+   * Print a barcode. Multiple barcodes are supported, both 1D and 2D. Please see the sealed
+   * [BarcodeSpec] class for information on the supported barcode types.
    *
-   * QR Code printing is not affected by print mode (bold, double-strike, underline...) except for
-   * two settings: 1) Character size 2) Upside-down mode
-   *
-   * `content` must not be empty.
+   * @see BarcodeSpec
    */
-  public fun qr(content: String, errorCorrection: QrCorrectionLevel = QrCorrectionLevel.L) {
-    commands.add(Command.QrCode(content, errorCorrection))
+  public fun barcode(spec: BarcodeSpec) {
+    commands.add(spec.asCommand()) //
   }
 }

--- a/escpos4k/src/commonTest/kotlin/cz/multiplatform/escpos4k/core/ArrowAssertions.kt
+++ b/escpos4k/src/commonTest/kotlin/cz/multiplatform/escpos4k/core/ArrowAssertions.kt
@@ -1,0 +1,21 @@
+package cz.multiplatform.escpos4k.core
+
+import arrow.core.Either
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+inline fun <A, B> Either<A, B>.shouldBeLeft(expected: A) {
+  shouldBeInstanceOf<Either.Left<A>>().value shouldBe expected
+}
+
+inline fun <A, B> Either<A, B>.shouldBeLeft() {
+  shouldBeInstanceOf<Either.Left<A>>()
+}
+
+inline fun <A, B> Either<A, B>.shouldBeRight(expected: A) {
+  shouldBeInstanceOf<Either.Right<B>>().value shouldBe expected
+}
+
+inline fun <A, B> Either<A, B>.shouldBeRight() {
+  shouldBeInstanceOf<Either.Right<B>>()
+}

--- a/escpos4k/src/commonTest/kotlin/cz/multiplatform/escpos4k/core/ArrowAssertions.kt
+++ b/escpos4k/src/commonTest/kotlin/cz/multiplatform/escpos4k/core/ArrowAssertions.kt
@@ -8,14 +8,14 @@ inline fun <A, B> Either<A, B>.shouldBeLeft(expected: A) {
   shouldBeInstanceOf<Either.Left<A>>().value shouldBe expected
 }
 
-inline fun <A, B> Either<A, B>.shouldBeLeft() {
-  shouldBeInstanceOf<Either.Left<A>>()
+inline fun <A, B> Either<A, B>.shouldBeLeft(): A {
+  return shouldBeInstanceOf<Either.Left<A>>().value
 }
 
 inline fun <A, B> Either<A, B>.shouldBeRight(expected: B) {
   shouldBeInstanceOf<Either.Right<B>>().value shouldBe expected
 }
 
-inline fun <A, B> Either<A, B>.shouldBeRight() {
-  shouldBeInstanceOf<Either.Right<B>>()
+inline fun <A, B> Either<A, B>.shouldBeRight(): B {
+  return shouldBeInstanceOf<Either.Right<B>>().value
 }

--- a/escpos4k/src/commonTest/kotlin/cz/multiplatform/escpos4k/core/ArrowAssertions.kt
+++ b/escpos4k/src/commonTest/kotlin/cz/multiplatform/escpos4k/core/ArrowAssertions.kt
@@ -12,7 +12,7 @@ inline fun <A, B> Either<A, B>.shouldBeLeft() {
   shouldBeInstanceOf<Either.Left<A>>()
 }
 
-inline fun <A, B> Either<A, B>.shouldBeRight(expected: A) {
+inline fun <A, B> Either<A, B>.shouldBeRight(expected: B) {
   shouldBeInstanceOf<Either.Right<B>>().value shouldBe expected
 }
 

--- a/escpos4k/src/commonTest/kotlin/cz/multiplatform/escpos4k/core/BarcodeSpecTest.kt
+++ b/escpos4k/src/commonTest/kotlin/cz/multiplatform/escpos4k/core/BarcodeSpecTest.kt
@@ -1,17 +1,34 @@
 package cz.multiplatform.escpos4k.core
 
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.ints.shouldBeExactly
 
 class BarcodeSpecTest : FunSpec() {
   init {
     context("QRCodeSpec") {
       test("factory enforces length limits") {
-        BarcodeSpec.QRCodeSpec.create("", QrCorrectionLevel.Q)
+        BarcodeSpec.QRCodeSpec.create("")
             .shouldBeLeft(BarcodeSpec.QRCodeSpec.QrCodeError.EmptyContent)
 
         val longText = buildString { repeat(10_000) { append("1") } }
-        BarcodeSpec.QRCodeSpec.create(longText, QrCorrectionLevel.Q)
+        BarcodeSpec.QRCodeSpec.create(longText)
             .shouldBeLeft(BarcodeSpec.QRCodeSpec.QrCodeError.TooLong)
+      }
+    }
+
+    context("AztecCodeSpec") {
+      test("factory enforces text length limits") {
+        BarcodeSpec.AztecCodeSpec.create("")
+            .shouldBeLeft(BarcodeSpec.AztecCodeSpec.AztecCodeError.EmptyContent)
+
+        val longText = buildString { repeat(10_000) { append("1") } }
+        BarcodeSpec.AztecCodeSpec.create(longText)
+            .shouldBeLeft(BarcodeSpec.AztecCodeSpec.AztecCodeError.TooLong)
+      }
+
+      test("factory coerces EC percentage into a valid range") {
+        BarcodeSpec.AztecCodeSpec.create("hello", -5).shouldBeRight().ecPercent shouldBeExactly 5
+        BarcodeSpec.AztecCodeSpec.create("hello", 100).shouldBeRight().ecPercent shouldBeExactly 95
       }
     }
   }

--- a/escpos4k/src/commonTest/kotlin/cz/multiplatform/escpos4k/core/BarcodeSpecTest.kt
+++ b/escpos4k/src/commonTest/kotlin/cz/multiplatform/escpos4k/core/BarcodeSpecTest.kt
@@ -9,11 +9,11 @@ class BarcodeSpecTest : FunSpec() {
     context("QRCodeSpec") {
       test("factory enforces length limits") {
         BarcodeSpec.QRCodeSpec.create("")
-            .shouldBeLeft(BarcodeSpec.QRCodeSpec.QrCodeError.EmptyContent)
+            .shouldBeLeft(BarcodeSpec.QRCodeSpec.QRCodeError.EmptyContent)
 
         val longText = buildString { repeat(10_000) { append("1") } }
         BarcodeSpec.QRCodeSpec.create(longText)
-            .shouldBeLeft(BarcodeSpec.QRCodeSpec.QrCodeError.TooLong)
+            .shouldBeLeft(BarcodeSpec.QRCodeSpec.QRCodeError.TooLong)
       }
     }
 
@@ -46,27 +46,53 @@ class BarcodeSpecTest : FunSpec() {
 
     context("UPC-A") {
       test("factory enforces length limits") {
-        BarcodeSpec.UpcASpec.create("1234567890123", HriPosition.BELOW)
-            .shouldBeLeft(BarcodeSpec.UpcASpec.UpcAError.IncorrectLength)
-        BarcodeSpec.UpcASpec.create("123456789", HriPosition.BELOW)
-            .shouldBeLeft(BarcodeSpec.UpcASpec.UpcAError.IncorrectLength)
+        BarcodeSpec.UPCASpec.create("1234567890123", HriPosition.BELOW)
+            .shouldBeLeft(BarcodeSpec.UPCASpec.UPCAError.IncorrectLength)
+        BarcodeSpec.UPCASpec.create("123456789", HriPosition.BELOW)
+            .shouldBeLeft(BarcodeSpec.UPCASpec.UPCAError.IncorrectLength)
       }
 
       test("factory calculates correct check digit if length == 11") {
-        BarcodeSpec.UpcASpec.create("03600029145", HriPosition.BELOW)
+        BarcodeSpec.UPCASpec.create("03600029145", HriPosition.BELOW)
             .shouldBeRight()
             .text
             .shouldBe("036000291452")
       }
 
       test("factory enforces correct digit if length == 12") {
-        BarcodeSpec.UpcASpec.create("036000291453", HriPosition.BELOW)
-            .shouldBeLeft(BarcodeSpec.UpcASpec.UpcAError.InvalidCheckDigit(2, 3))
+        BarcodeSpec.UPCASpec.create("036000291453", HriPosition.BELOW)
+            .shouldBeLeft(BarcodeSpec.UPCASpec.UPCAError.InvalidCheckDigit(2, 3))
       }
 
       test("factory enforces digits only") {
-        BarcodeSpec.UpcASpec.create("03600029145x", HriPosition.BELOW)
-            .shouldBeLeft(BarcodeSpec.UpcASpec.UpcAError.IllegalCharacter(11, 'x'))
+        BarcodeSpec.UPCASpec.create("03600029145x", HriPosition.BELOW)
+            .shouldBeLeft(BarcodeSpec.UPCASpec.UPCAError.IllegalCharacter(11, 'x'))
+      }
+    }
+
+    context("EAN-13") {
+      test("factory enforces length limits") {
+        BarcodeSpec.EAN13Spec.create("12345678901234", HriPosition.BELOW)
+            .shouldBeLeft(BarcodeSpec.EAN13Spec.EAN13Error.IncorrectLength)
+        BarcodeSpec.EAN13Spec.create("123456789", HriPosition.BELOW)
+            .shouldBeLeft(BarcodeSpec.EAN13Spec.EAN13Error.IncorrectLength)
+      }
+
+      test("factory calculates correct check digit if length == 12") {
+        BarcodeSpec.EAN13Spec.create("400638133393", HriPosition.BELOW)
+            .shouldBeRight()
+            .text
+            .shouldBe("4006381333931")
+      }
+
+      test("factory enforces correct digit if length == 13") {
+        BarcodeSpec.EAN13Spec.create("4006381333935", HriPosition.BELOW)
+            .shouldBeLeft(BarcodeSpec.EAN13Spec.EAN13Error.InvalidCheckDigit(1, 5))
+      }
+
+      test("factory enforces digits only") {
+        BarcodeSpec.EAN13Spec.create("40x6381333931", HriPosition.BELOW)
+            .shouldBeLeft(BarcodeSpec.EAN13Spec.EAN13Error.IllegalCharacter(2, 'x'))
       }
     }
   }

--- a/escpos4k/src/commonTest/kotlin/cz/multiplatform/escpos4k/core/BarcodeSpecTest.kt
+++ b/escpos4k/src/commonTest/kotlin/cz/multiplatform/escpos4k/core/BarcodeSpecTest.kt
@@ -31,5 +31,16 @@ class BarcodeSpecTest : FunSpec() {
         BarcodeSpec.AztecCodeSpec.create("hello", 100).shouldBeRight().ecPercent shouldBeExactly 95
       }
     }
+
+    context("DataMatrixSpec") {
+      test("factory enforces text length limits") {
+        BarcodeSpec.DataMatrixSpec.create("")
+            .shouldBeLeft(BarcodeSpec.DataMatrixSpec.DataMatrixError.EmptyContent)
+
+        val longText = buildString { repeat(10_000) { append("1") } }
+        BarcodeSpec.DataMatrixSpec.create(longText)
+            .shouldBeLeft(BarcodeSpec.DataMatrixSpec.DataMatrixError.TooLong)
+      }
+    }
   }
 }

--- a/escpos4k/src/commonTest/kotlin/cz/multiplatform/escpos4k/core/BarcodeSpecTest.kt
+++ b/escpos4k/src/commonTest/kotlin/cz/multiplatform/escpos4k/core/BarcodeSpecTest.kt
@@ -95,5 +95,31 @@ class BarcodeSpecTest : FunSpec() {
             .shouldBeLeft(BarcodeSpec.EAN13Spec.EAN13Error.IllegalCharacter(2, 'x'))
       }
     }
+
+    context("EAN-8") {
+      test("factory enforces length limits") {
+        BarcodeSpec.EAN8Spec.create("123456789", HriPosition.BELOW)
+            .shouldBeLeft(BarcodeSpec.EAN8Spec.EAN8Error.IncorrectLength)
+        BarcodeSpec.EAN8Spec.create("123456", HriPosition.BELOW)
+            .shouldBeLeft(BarcodeSpec.EAN8Spec.EAN8Error.IncorrectLength)
+      }
+
+      test("factory calculates correct check digit if length == 7") {
+        BarcodeSpec.EAN8Spec.create("7351353", HriPosition.BELOW)
+            .shouldBeRight()
+            .text
+            .shouldBe("73513537")
+      }
+
+      test("factory enforces correct digit if length == 8") {
+        BarcodeSpec.EAN8Spec.create("73513530", HriPosition.BELOW)
+            .shouldBeLeft(BarcodeSpec.EAN8Spec.EAN8Error.InvalidCheckDigit(7, 0))
+      }
+
+      test("factory enforces digits only") {
+        BarcodeSpec.EAN8Spec.create("73513x37", HriPosition.BELOW)
+            .shouldBeLeft(BarcodeSpec.EAN8Spec.EAN8Error.IllegalCharacter(5, 'x'))
+      }
+    }
   }
 }

--- a/escpos4k/src/commonTest/kotlin/cz/multiplatform/escpos4k/core/BarcodeSpecTest.kt
+++ b/escpos4k/src/commonTest/kotlin/cz/multiplatform/escpos4k/core/BarcodeSpecTest.kt
@@ -1,0 +1,18 @@
+package cz.multiplatform.escpos4k.core
+
+import io.kotest.core.spec.style.FunSpec
+
+class BarcodeSpecTest : FunSpec() {
+  init {
+    context("QRCodeSpec") {
+      test("factory enforces length limits") {
+        BarcodeSpec.QRCodeSpec.create("", QrCorrectionLevel.Q)
+            .shouldBeLeft(BarcodeSpec.QRCodeSpec.QrCodeError.EmptyContent)
+
+        val longText = buildString { repeat(10_000) { append("1") } }
+        BarcodeSpec.QRCodeSpec.create(longText, QrCorrectionLevel.Q)
+            .shouldBeLeft(BarcodeSpec.QRCodeSpec.QrCodeError.TooLong)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Reworked handling of barcode commands in `CommandBuilder`. Instead of having a function per barcode we have a single function `CommandBuilder.barcode(BarcodeSpec)`. Barcodes are implemented by adding subclasses to the sealed `BarcodeSpec` hierarchy.

BarcodeSpec instaces are created with a factory function that validates the input arguments and returns `Either<BarcodeError, BarcodeSpec>`.

For each new barcode there is also the corresponding `Command` which handles the actual conversion of the `BarcodeSpec` to `ByteArray`. `Command` can be obtained from `BarcodeSpec` with its `asCommand(): Command` method.