### PR TITLE
Generic segmented line builder

### DIFF
--- a/escpos4k/build.gradle.kts
+++ b/escpos4k/build.gradle.kts
@@ -108,3 +108,7 @@ android {
     }
   }
 }
+
+tasks.withType<Test> {
+  systemProperty("kotest.assertions.collection.print.size", 100)
+}

--- a/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/core/CommandBuilder.kt
+++ b/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/core/CommandBuilder.kt
@@ -20,7 +20,7 @@ package cz.multiplatform.escpos4k.core
 @Suppress("MemberVisibilityCanBePrivate")
 public class CommandBuilder
 internal constructor(
-    internal val charsPerLine: Int,
+    internal val config: PrinterConfiguration,
 ) {
   internal val commands: MutableList<Command> =
       mutableListOf(Command.Initialize, Command.SelectCharset(Charset.default))
@@ -114,7 +114,8 @@ internal constructor(
   ) {
     // TODO: Extract the character width from [commands] instead of forcing the caller to supply it.
     val numSpaces =
-        (charsPerLine - left.length * charWidth - right.length * charWidth).coerceAtLeast(minSpace)
+        (config.charactersPerLine - left.length * charWidth - right.length * charWidth)
+            .coerceAtLeast(minSpace)
     val spacer = buildString { repeat(numSpaces) { append(' ') } }
 
     textAlign(TextAlignment.LEFT)

--- a/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/core/CommandBuilder.kt
+++ b/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/core/CommandBuilder.kt
@@ -374,17 +374,31 @@ internal constructor(
    * is too long to fit, so it breaks downwards.
    *
    * ```
-   * // Let the line length be 16. Each segment gets 8 spaces to work with.
+   * // Let the line length be 16. Each segment gets 8 single-width spaces to work with.
    * segmentedLine(
    *   LineSegment("seg1", TextAlignment.LEFT),
-   *   LineSegment("seg2 overflow", TextAlignment.RIGHT),
+   *   LineSegment("seg2_overflow", TextAlignment.RIGHT),
    * )
    *
-   * // Output:
-   * ___________________
-   * |seg1    |seg2 ove|
+   * textSize(2, 1) // Double character width
+   * segmentedLine(
+   *   LineSegment("seg3", TextAlignment.LEFT),
+   *   LineSegment("seg4_overflow", TextAlignment.RIGHT),
+   * )
+   *
+   * // Printed output (the paper/segment bounds are outlined with '|' and '_'):
+   *
+   * -------------------
+   * |seg1    |seg2_ove|
    * |        |   rflow|
-   * ___________________
+   * -------------------
+   *
+   * -----------
+   * |seg3|seg4|         <-- Only 8 total characters fit per line now
+   * |    |_ove|             since they are double width.
+   * |    |rflo|
+   * |    |   w|
+   * -----------
    * ```
    */
   public fun segmentedLine(segments: List<LineSegment>) {

--- a/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/core/CommandBuilder.kt
+++ b/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/core/CommandBuilder.kt
@@ -86,51 +86,6 @@ internal constructor(
   }
 
   /**
-   * Print the two text fragments in two columns and terminate the line.
-   *
-   * The two text fragments are spaced out such that the `left` text is aligned to the start of the
-   * line and the `right` text is aligned to the end of the line.
-   *
-   * @param minSpace The minimum amount of spaces between the two columns, default 1.
-   * @see twoColumnText
-   */
-  public fun twoColumnLine(
-      left: String,
-      right: String,
-      charWidth: Int = 1,
-      minSpace: Int = 1,
-  ) {
-    twoColumnText(left, right + "\n", charWidth, minSpace)
-  }
-
-  /**
-   * Print the two text fragments in two columns without terminating the line.
-   *
-   * The two text fragments are spaced out such that the `left` text is aligned to the start of the
-   * line and the `right` text is aligned to the end of the line.
-   *
-   * @param minSpace The minimum amount of spaces between the two columns, default 1.
-   * @see twoColumnLine
-   */
-  public fun twoColumnText(
-      left: String,
-      right: String,
-      charWidth: Int = 1,
-      minSpace: Int = 1,
-  ) {
-    // TODO: Extract the character width from [commands] instead of forcing the caller to supply it.
-    val numSpaces =
-        (config.charactersPerLine - left.length * charWidth - right.length * charWidth)
-            .coerceAtLeast(minSpace)
-    val spacer = buildString { repeat(numSpaces) { append(' ') } }
-
-    textAlign(TextAlignment.LEFT)
-    text(left)
-    text(spacer)
-    text(right)
-  }
-
-  /**
    * Select a [Charset]. Text printed with [text] will be encoded to single-byte characters
    * according to this character set.
    *

--- a/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/core/CommandBuilder.kt
+++ b/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/core/CommandBuilder.kt
@@ -48,6 +48,9 @@ internal constructor(
    * @see line
    */
   public fun text(text: String) {
+    if (text.isEmpty()) {
+      return
+    }
     val currentCharset =
         commands.lastOfTypeOrNull<Command.SelectCharset>()?.charset ?: Charset.default
     commands.add(Command.Text(text, currentCharset))

--- a/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/core/CommandBuilder.kt
+++ b/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/core/CommandBuilder.kt
@@ -452,14 +452,20 @@ internal constructor(
         }
       }
 
-      withTextSize(1, textSize.height) {
-        val spacerString = buildString { repeat(leftSpacer) { append(" ") } }
-        text(spacerString)
+      if (leftSpacer > 0) {
+        withTextSize(1, textSize.height) {
+          val spacerString = buildString { repeat(leftSpacer) { append(" ") } }
+          text(spacerString)
+        }
       }
+
       text(segment.text)
-      withTextSize(1, textSize.height) {
-        val spacerString = buildString { repeat(rightSpacer) { append(" ") } }
-        text(spacerString)
+
+      if (rightSpacer > 0) {
+        withTextSize(1, textSize.height) {
+          val spacerString = buildString { repeat(rightSpacer) { append(" ") } }
+          text(spacerString)
+        }
       }
     }
     text("\n")

--- a/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/core/PrinterConfiguration.kt
+++ b/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/core/PrinterConfiguration.kt
@@ -1,0 +1,48 @@
+/*
+ *    Copyright 2022 Ondřej Karmazín
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package cz.multiplatform.escpos4k.core
+
+/** A collection of attributes describing the basic properties of a printer. */
+public data class PrinterConfiguration(
+    //    /**
+    //     * Dots Per Inch - resolution of this printer. The typical value is `203 DPI == 8 Dots Per
+    // mm`.
+    //     *
+    //     * **NOTE**: All other dimensions are measured in millimetres.
+    //     */
+    //    val dpi: Int,
+
+    /**
+     * How many single-width characters can the printer put on a single line when using the
+     * factory-default font.
+     *
+     * For printers using the 57mm paper width, this is usually 32 or 42.
+     *
+     * Used in:
+     * - The layout algorithm of column-based command builder. The algorithm needs to know the total
+     * length of a line to be able to distribute the space among the columns.
+     */
+    val charactersPerLine: Int,
+
+//    /**
+//     * The total printable width in millimetres. In the typical case this number will be about
+//     * approximately `<paper width in mm> - 10` (printer leaves 5 mm margin on each side).
+//     *
+//     * Why is this important?
+//     */
+//    val effectivePrintingWidthMM: Int,
+)

--- a/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/core/PrinterConnection.kt
+++ b/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/core/PrinterConnection.kt
@@ -50,17 +50,12 @@ public interface PrinterConnection {
    *   bold(false)
    * }
    * ```
-   *
-   * @param charsPerLine The line length of your printer. Used for calculating the column padding in
-   * `twoColumnText` and other similar commands. This number differs among different printer
-   * devices. For example: `Epson TM-P20` prints 42 characters per line while `Cashino PTP-II` only
-   * prints 32 characters per line on the same 57mm paper.
    */
   public suspend fun print(
-      charsPerLine: Int = Constants.charsPerLine60mm,
+      config: PrinterConfiguration,
       content: CommandBuilder.() -> Unit
   ): PrintError? {
-    val builder = CommandBuilder(Constants.charsPerLine60mm).apply(content)
+    val builder = CommandBuilder(config).apply(content)
     val bytes = builder.commands.flatMap { it.bytes().asSequence() }.toByteArray()
     return printRaw(bytes)
   }

--- a/escpos4k/src/commonTest/kotlin/cz/multiplatform/escpos4k/core/CommandBuilderTest.kt
+++ b/escpos4k/src/commonTest/kotlin/cz/multiplatform/escpos4k/core/CommandBuilderTest.kt
@@ -12,6 +12,12 @@ class CommandBuilderTest : FunSpec() {
       CommandBuilder(defaultConfig).commands shouldContainExactly initSequence
     }
 
+    context("text") {
+      test("empty string does nothing") {
+        CommandBuilder(defaultConfig).apply { text("") }.commands shouldContainExactly initSequence
+      }
+    }
+
     // todo text
 
     // todo line

--- a/escpos4k/src/commonTest/kotlin/cz/multiplatform/escpos4k/core/CommandBuilderTest.kt
+++ b/escpos4k/src/commonTest/kotlin/cz/multiplatform/escpos4k/core/CommandBuilderTest.kt
@@ -4,12 +4,12 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactly
 
 class CommandBuilderTest : FunSpec() {
-  private val charsPerLine = 32
+  private val defaultConfig = PrinterConfiguration(32)
   private val initSequence = listOf(Command.Initialize, Command.SelectCharset(Charset.default))
 
   init {
     test("fresh CommandBuilder initial sequence") {
-      CommandBuilder(charsPerLine).commands shouldContainExactly initSequence
+      CommandBuilder(defaultConfig).commands shouldContainExactly initSequence
     }
 
     // todo text
@@ -23,7 +23,7 @@ class CommandBuilderTest : FunSpec() {
     context("charset") {
       test("style is not applied if same as current") {
         val builder =
-            CommandBuilder(charsPerLine).apply {
+            CommandBuilder(defaultConfig).apply {
               charset(Charset.default)
               charset(Charset.CP850)
               charset(Charset.CP850)
@@ -39,7 +39,7 @@ class CommandBuilderTest : FunSpec() {
     context("withCharset") {
       test("style is not applied if same as current") {
         val builder =
-            CommandBuilder(charsPerLine).apply {
+            CommandBuilder(defaultConfig).apply {
               withCharset(Charset.default) {
                 withCharset(Charset.CP850) {
                   withCharset(Charset.CP850) {
@@ -64,7 +64,7 @@ class CommandBuilderTest : FunSpec() {
     context("textSize") {
       test("style is not applied if same as current") {
         val builder =
-            CommandBuilder(charsPerLine).apply {
+            CommandBuilder(defaultConfig).apply {
               textSize(1, 1)
               textSize(2, 2)
               textSize(2, 2)
@@ -78,7 +78,7 @@ class CommandBuilderTest : FunSpec() {
     context("withTextSize") {
       test("style is not applied if same as current") {
         val builder =
-            CommandBuilder(charsPerLine).apply {
+            CommandBuilder(defaultConfig).apply {
               withTextSize(1, 1) {
                 withTextSize(2, 2) {
                   withTextSize(2, 2) {
@@ -102,7 +102,7 @@ class CommandBuilderTest : FunSpec() {
     context("bold") {
       test("style is not applied if same as current") {
         val builder =
-            CommandBuilder(charsPerLine).apply {
+            CommandBuilder(defaultConfig).apply {
               bold(false)
               bold(true)
               bold(true)
@@ -117,7 +117,7 @@ class CommandBuilderTest : FunSpec() {
     context("withBold") {
       test("style is not applied if same as current") {
         val builder =
-            CommandBuilder(charsPerLine).apply {
+            CommandBuilder(defaultConfig).apply {
               withBold(false) {
                 withBold(true) {
                   withBold(true) {
@@ -142,7 +142,7 @@ class CommandBuilderTest : FunSpec() {
     context("underline") {
       test("style is not applied if same as current") {
         val builder =
-            CommandBuilder(charsPerLine).apply {
+            CommandBuilder(defaultConfig).apply {
               underline(false)
               underline(true)
               underline(true)
@@ -156,7 +156,7 @@ class CommandBuilderTest : FunSpec() {
     context("withUnderline") {
       test("style is not applied if same as current") {
         val builder =
-            CommandBuilder(charsPerLine).apply {
+            CommandBuilder(defaultConfig).apply {
               withUnderline(false) {
                 withUnderline(true) {
                   withUnderline(true) {
@@ -181,7 +181,7 @@ class CommandBuilderTest : FunSpec() {
     context("italics") {
       test("style is not applied if same as current") {
         val builder =
-            CommandBuilder(charsPerLine).apply {
+            CommandBuilder(defaultConfig).apply {
               italics(false)
               italics(true)
               italics(true)
@@ -195,7 +195,7 @@ class CommandBuilderTest : FunSpec() {
     context("withItalics") {
       test("style is not applied if same as current") {
         val builder =
-            CommandBuilder(charsPerLine).apply {
+            CommandBuilder(defaultConfig).apply {
               withItalics(false) {
                 withItalics(true) {
                   withItalics(true) {
@@ -220,7 +220,7 @@ class CommandBuilderTest : FunSpec() {
     context("textAlign") {
       test("style is not applied if same as current") {
         val builder =
-            CommandBuilder(charsPerLine).apply {
+            CommandBuilder(defaultConfig).apply {
               textAlign(TextAlignment.LEFT)
               textAlign(TextAlignment.CENTER)
               textAlign(TextAlignment.CENTER)

--- a/escpos4k/src/commonTest/kotlin/cz/multiplatform/escpos4k/core/CommandBuilderTest.kt
+++ b/escpos4k/src/commonTest/kotlin/cz/multiplatform/escpos4k/core/CommandBuilderTest.kt
@@ -238,5 +238,50 @@ class CommandBuilderTest : FunSpec() {
                 Command.Justify(TextAlignment.RIGHT)
       }
     }
+
+    context("segmentedLine") {
+      test("empty segments") {
+        val builder =
+            CommandBuilder(defaultConfig).apply {
+              segmentedLine()
+              segmentedLine()
+            }
+        builder.commands shouldContainExactly initSequence
+      }
+
+      test("prints at least 1 char per segment") {
+        val builder =
+            CommandBuilder(PrinterConfiguration(10)).apply {
+              textSize(8, 1)
+              segmentedLine(
+                  LineSegment("12", TextAlignment.LEFT), LineSegment("3", TextAlignment.LEFT))
+            }
+        builder.commands shouldContainExactly
+            initSequence +
+                Command.TextSize(8, 1) +
+                Command.TextSize(1, 1) +
+                Command.TextSize(8, 1) +
+                Command.Text("1", Charset.default) +
+                Command.TextSize(1, 1) +
+                Command.TextSize(8, 1) +
+                Command.TextSize(1, 1) +
+                Command.TextSize(8, 1) +
+                Command.Text("3", Charset.default) +
+                Command.TextSize(1, 1) +
+                Command.TextSize(8, 1) +
+                Command.Text("\n", Charset.default) +
+                Command.TextSize(1, 1) +
+                Command.TextSize(8, 1) +
+                Command.Text("2", Charset.default) +
+                Command.TextSize(1, 1) +
+                Command.TextSize(8, 1) +
+                Command.TextSize(1, 1) +
+                Command.TextSize(8, 1) +
+                Command.TextSize(1, 1) +
+                Command.Text("     ", Charset.default) +
+                Command.TextSize(8, 1) +
+                Command.Text("\n", Charset.default)
+      }
+    }
   }
 }

--- a/escpos4k/src/commonTest/kotlin/cz/multiplatform/escpos4k/core/CommandBuilderTest.kt
+++ b/escpos4k/src/commonTest/kotlin/cz/multiplatform/escpos4k/core/CommandBuilderTest.kt
@@ -259,24 +259,10 @@ class CommandBuilderTest : FunSpec() {
         builder.commands shouldContainExactly
             initSequence +
                 Command.TextSize(8, 1) +
-                Command.TextSize(1, 1) +
-                Command.TextSize(8, 1) +
                 Command.Text("1", Charset.default) +
-                Command.TextSize(1, 1) +
-                Command.TextSize(8, 1) +
-                Command.TextSize(1, 1) +
-                Command.TextSize(8, 1) +
                 Command.Text("3", Charset.default) +
-                Command.TextSize(1, 1) +
-                Command.TextSize(8, 1) +
                 Command.Text("\n", Charset.default) +
-                Command.TextSize(1, 1) +
-                Command.TextSize(8, 1) +
                 Command.Text("2", Charset.default) +
-                Command.TextSize(1, 1) +
-                Command.TextSize(8, 1) +
-                Command.TextSize(1, 1) +
-                Command.TextSize(8, 1) +
                 Command.TextSize(1, 1) +
                 Command.Text("     ", Charset.default) +
                 Command.TextSize(8, 1) +


### PR DESCRIPTION
This PR introduces a new builder: `segmentedLine`. This builder supersedes the `twoColumnLine` builder, allowing the caller to specify arbitrary number of columns. We call them "segments". 

The segments are each given an equal part of the line and are printed within this space. The segment text can be independently aligned to `LEFT, CENTER, RIGHT` within its bounds.

Segment spacing and alignment is done by surrounding the segment text with appropriate amounts of single-width space characters.

**Segment overflow**:
If a segment is too long for its allotted space, the text overflows onto the next line or lines. The overflown line keeps the text alignment.
```
// Let the line length be 16. Each segment gets 8 single spaces to work with

segmentedLine(
  LineSegment("seg1", TextAlignment.LEFT),
  LineSegment("seg2_overflow", TextAlignment.RIGHT),
)

textSize(2, 1) // Double the character width
segmentedLine(
  LineSegment("seg1", TextAlignment.LEFT),
  LineSegment("seg2_overflow", TextAlignment.RIGHT),
)

// Output:
___________________
|seg1    |seg2_ove|
|        |   rflow|
___________________
___________
|seg1|seg2|            <-- double width = only 8/2 characters fit per segment
|    |_ove|
|    |rflo|
|    |   w|
___________

```

Resolves #1, resolves #2 , resolves #16