### PR TITLE
Android Bluetooth access hardening

### DIFF
--- a/escpos4k/build.gradle.kts
+++ b/escpos4k/build.gradle.kts
@@ -85,7 +85,7 @@ kotlin {
 android {
   compileSdk = 31
   defaultConfig {
-    minSdk = 21
+    minSdk = 23
     targetSdk = 31
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/escpos4k/src/androidMain/kotlin/cz/multiplatform/escpos4k/bluetooth/BluetoothPrinterManager.android.kt
+++ b/escpos4k/src/androidMain/kotlin/cz/multiplatform/escpos4k/bluetooth/BluetoothPrinterManager.android.kt
@@ -16,67 +16,143 @@
 
 package cz.multiplatform.escpos4k.bluetooth
 
+import android.Manifest
 import android.annotation.SuppressLint
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothDevice as PlatformBluetoothDevice
 import android.bluetooth.BluetoothManager
 import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import arrow.core.Either
+import arrow.core.continuations.either
+import arrow.core.identity
+import arrow.core.left
+import arrow.core.rightIfNotNull
 import java.io.IOException
 import java.util.UUID
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 
 public fun BluetoothPrinterManager(context: Context): BluetoothPrinterManager =
     AndroidBluetoothPrinterManager(context)
 
-private class AndroidBluetoothPrinterManager(context: Context) : AbstractBluetoothPrinterManager() {
+private class AndroidBluetoothPrinterManager(context: Context) : BluetoothPrinterManager {
   private val context: Context = context.applicationContext
 
   @SuppressLint("MissingPermission")
-  override fun allPairedDevices(): List<BluetoothDevice> {
-    return context.bluetoothManager().adapter.bondedDevices.map { platformDevice ->
-      BluetoothDevice(
-          platformDevice.address,
-          platformDevice.name,
-          platformDevice.type.toBtType(),
-          platformDevice.uuids.orEmpty().map { it.uuid.toString() },
-          platformDevice.bluetoothClass.majorDeviceClass,
-          platformDevice.bluetoothClass.deviceClass)
-    }
+  override suspend fun openConnection(
+      printer: BluetoothDevice
+  ): Either<BluetoothError, BluetoothPrinterConnection> {
+    return runCatching {
+          withContext(Dispatchers.IO) {
+            either {
+              val device =
+                  context.allPlatformDevices().bind().firstOrNull { it.address == printer.address }
+                      ?: shift<Nothing>(BluetoothError.DeviceNotFound(printer))
+              val serviceUUID =
+                  printer.uuids.firstOrNull()?.let(UUID::fromString) ?: UUID.randomUUID()
+              val socket = device.createRfcommSocketToServiceRecord(serviceUUID)
+
+              currentCoroutineContext().ensureActive()
+              socket.connect()
+              currentCoroutineContext().ensureActive()
+
+              BluetoothPrinterConnection(AndroidBluetoothDeviceConnection(socket, printer))
+            }
+          }
+        }
+        .fold(::identity) { cause ->
+          when (cause) {
+            is CancellationException -> throw cause
+            is IOException -> {
+              // IOException thrown from createSocket() or connect(). There are multiple reasons
+              // for this failure ranging from connection errors to missing permissions.
+              // FIXME: Investigate the possible contents of the IOException to provide a more
+              //        specific error.
+              BluetoothError.Unknown(cause).left()
+            }
+            else -> {
+              BluetoothError.Unknown(cause).left()
+            }
+          }
+        }
   }
 
-  @SuppressLint("MissingPermission")
-  override suspend fun openDeviceConnection(printer: BluetoothDevice): BluetoothDeviceConnection? {
-    return withContext(Dispatchers.IO) {
-      try {
-        val serviceUUID = printer.uuids.firstOrNull()?.let(UUID::fromString) ?: UUID.randomUUID()
-        val socket =
-            context.findPlatformDevice(printer)?.createRfcommSocketToServiceRecord(serviceUUID)
-                ?: return@withContext null
-
-        socket.connect()
-
-        AndroidBluetoothDeviceConnection(socket, printer)
-      } catch (e: IOException) {
-        null
+  override fun pairedPrinters(): Either<BluetoothError, List<BluetoothDevice>> =
+      allPairedDevices().map { allDevices ->
+        allDevices.filter { device ->
+          val classImaging = 1536
+          val classPrinter = 1664
+          device.majorDeviceClass == classImaging &&
+              (device.deviceClass == classPrinter || device.deviceClass == classImaging)
+        }
       }
-    }
+
+  @SuppressLint("MissingPermission")
+  private fun allPairedDevices(): Either<BluetoothError, List<BluetoothDevice>> {
+    return runCatching {
+          either.eager {
+            val platformDevices = context.allPlatformDevices().bind()
+            platformDevices.map { platformDevice ->
+              BluetoothDevice(
+                  platformDevice.address,
+                  platformDevice.name,
+                  platformDevice.type.toBtType(),
+                  platformDevice.uuids.orEmpty().map { it.uuid.toString() },
+                  platformDevice.bluetoothClass.majorDeviceClass,
+                  platformDevice.bluetoothClass.deviceClass)
+            }
+          }
+        }
+        .fold(::identity, { BluetoothError.Unknown(it).left() })
   }
 }
 
 private fun Int.toBtType(): BluetoothType =
     when (this) {
-      android.bluetooth.BluetoothDevice.DEVICE_TYPE_CLASSIC -> BluetoothType.Classic
-      android.bluetooth.BluetoothDevice.DEVICE_TYPE_LE -> BluetoothType.LowEnergy
-      android.bluetooth.BluetoothDevice.DEVICE_TYPE_DUAL -> BluetoothType.Dual
-      android.bluetooth.BluetoothDevice.DEVICE_TYPE_UNKNOWN -> BluetoothType.Unknown
+      PlatformBluetoothDevice.DEVICE_TYPE_CLASSIC -> BluetoothType.Classic
+      PlatformBluetoothDevice.DEVICE_TYPE_LE -> BluetoothType.LowEnergy
+      PlatformBluetoothDevice.DEVICE_TYPE_DUAL -> BluetoothType.Dual
+      PlatformBluetoothDevice.DEVICE_TYPE_UNKNOWN -> BluetoothType.Unknown
       else -> BluetoothType.Unknown
     }
 
-internal fun Context.bluetoothManager(): BluetoothManager =
-    getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
+private fun Context.bluetoothManager(): Either<BluetoothError, BluetoothManager> {
+  val manager = getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager?
+  return manager.rightIfNotNull { BluetoothError.BluetoothNotAvailable }
+}
 
 @SuppressLint("MissingPermission")
-internal fun Context.findPlatformDevice(
-    device: BluetoothDevice
-): android.bluetooth.BluetoothDevice? {
-  return bluetoothManager().adapter.bondedDevices.firstOrNull { it.address == device.address }
+private fun Context.allPlatformDevices(): Either<BluetoothError, List<PlatformBluetoothDevice>> {
+  return runCatching {
+        either.eager {
+          val manager = bluetoothManager().bind()
+          val adapter = manager.adapter
+
+          if (adapter.state != BluetoothAdapter.STATE_ON) {
+            shift<Nothing>(BluetoothError.BluetoothOff)
+          }
+
+          if (!hasBondedDevicesPermission()) {
+            shift<Nothing>(BluetoothError.AccessDenied)
+          }
+
+          adapter.bondedDevices?.toList().orEmpty()
+        }
+      }
+      .fold(::identity, { BluetoothError.Unknown(it).left() })
+}
+
+private fun Context.hasBondedDevicesPermission(): Boolean {
+  val permission =
+      if (Build.VERSION.SDK_INT >= 31) {
+        Manifest.permission.BLUETOOTH_CONNECT
+      } else {
+        Manifest.permission.BLUETOOTH
+      }
+  return checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED
 }

--- a/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/bluetooth/BluetoothError.kt
+++ b/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/bluetooth/BluetoothError.kt
@@ -1,0 +1,73 @@
+/*
+ *    Copyright 2022 Ondřej Karmazín
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+@file:Suppress("MemberVisibilityCanBePrivate")
+
+package cz.multiplatform.escpos4k.bluetooth
+
+/** Errors encountered when accessing Bluetooth. */
+public sealed interface BluetoothError {
+
+  /**
+   * The current device has no Bluetooth capability.
+   *
+   * Android note: This happens when `getSystemService(BLUETOOTH) == null`.
+   */
+  public object BluetoothNotAvailable : BluetoothError
+
+  /**
+   * The current device has Bluetooth capabilities but Bluetooth is turned off.
+   *
+   * Android note: This happens when `BluetoothAdapter.state != STATE_ON`
+   */
+  public object BluetoothOff : BluetoothError
+
+  /**
+   * The operating system denied access to Bluetooth. The application should request this permission
+   * from the user.
+   *
+   * Android note: Likely the application is running on API 31+ and the `BLUETOOTH_CONNECT`
+   * permission was not granted. On lower API levels the access should be granted automatically by
+   * the OS.
+   */
+  public object AccessDenied : BluetoothError
+
+  /**
+   * The device could not be found by the operating system. It may have been disconnected after
+   * initial device lookup.
+   */
+  public class DeviceNotFound(public val searched: BluetoothDevice) : BluetoothError {
+    override fun toString(): String {
+      return "DeviceNotFound(searched=$searched)"
+    }
+  }
+
+  /**
+   * An unknown error occurred, [cause] likely contains the underlying exception, although it may
+   * also be `null`.
+   *
+   * These errors should be relatively uncommon as they are usually produced by internal unhandled
+   * error safety nets.
+   *
+   * If you find this error to be produced regularly, or with a cause that looks like it should have
+   * been mapped to a known error, please consider reporting the situation to the issue tracker.
+   */
+  public class Unknown(public val cause: Throwable?) : BluetoothError {
+    override fun toString(): String {
+      return "Unknown(cause=$cause)"
+    }
+  }
+}

--- a/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/bluetooth/BluetoothPrinterManager.kt
+++ b/escpos4k/src/commonMain/kotlin/cz/multiplatform/escpos4k/bluetooth/BluetoothPrinterManager.kt
@@ -16,39 +16,19 @@
 
 package cz.multiplatform.escpos4k.bluetooth
 
+import arrow.core.Either
+
 public interface BluetoothPrinterManager {
   /**
-   * Open the device so requests can be made.
+   * Open the device so requests can be made. You are responsible for closing the connection when
+   * you're done with it.
    *
    * @return The open connection or `null` if an error occurred.
    */
-  public suspend fun openConnection(printer: BluetoothDevice): BluetoothPrinterConnection?
+  public suspend fun openConnection(
+      printer: BluetoothDevice
+  ): Either<BluetoothError, BluetoothPrinterConnection>
 
   /** Returns the list of paired Bluetooth devices with Printer device class. */
-  public fun pairedPrinters(): List<BluetoothDevice>
-
-}
-
-internal abstract class AbstractBluetoothPrinterManager : BluetoothPrinterManager {
-
-  override suspend fun openConnection(printer: BluetoothDevice): BluetoothPrinterConnection? {
-    val connection = openDeviceConnection(printer) ?: return null
-    return BluetoothPrinterConnection(connection)
-  }
-
-  protected abstract fun allPairedDevices(): List<BluetoothDevice>
-
-  /** Returns the list of paired Bluetooth devices with Printer device class. */
-  override fun pairedPrinters(): List<BluetoothDevice> {
-
-    return allPairedDevices()
-        .filter { device ->
-          val classImaging = 1536
-          val classPrinter = 1664
-          device.majorDeviceClass == classImaging &&
-              (device.deviceClass == classPrinter || device.deviceClass == classImaging)
-        }
-  }
-
-  protected abstract suspend fun openDeviceConnection(printer: BluetoothDevice): BluetoothDeviceConnection?
+  public fun pairedPrinters(): Either<BluetoothError, List<BluetoothDevice>>
 }


### PR DESCRIPTION
This PR reimplements the Bluetooth access on Android, improving result types and fixing several crashes.

1) (**Breaking change**) Bluetooth APIs now return `Either<BluetoothError, TResult>` instead of a nullable `TResult`.
2) No longer crashes on API 31+ when `BLUETOOTH_CONNECT` permission is not granted.
3) No longer crashes when platform APIs return `null`. We previously forgot to check these platform types for `null`.
4) Cleaned up the `BluetoothPrinterManager` class hierarchy by removing an abstract base class. The base class only implemented a few lines of code, which was clearly not worth the trouble.

Closes #19 